### PR TITLE
Make homepage and issues links clickable

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,6 @@ readme: README.md
 authors:
   - Ansible (github.com/ansible)
 description: null
-license: GPL-3.0-or-later
 license_file: COPYING
 tags: null
 #dependencies:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,5 +12,5 @@ tags: null
 #  azure.azcollection: '>=0.1.0'
 repository: https://github.com:ansible-collections/community.azure
 documentation: https://github.com/ansible-collection-migration/community.azure/tree/master/docs
-homepage: https://github.com:ansible-collections/community..azure
-issues: https://github.com:ansible-collections/community..azure/issues
+homepage: https://github.com/ansible-collections/community.azure
+issues: https://github.com/ansible-collections/community.azure/issues


### PR DESCRIPTION
##### SUMMARY
I ran into this writing some general automation around collections.

And since this collection is a part of the alpha `ansible` package on PyPI, it's a primary part of datasets. Because of that, I would like the URLs to be resolvable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
I looked at `community.general`:

https://github.com/ansible-collections/community.general/blob/master/galaxy.yml

And their links follow this structure.

